### PR TITLE
Content: syllabus update

### DIFF
--- a/src/data/workshops.ts
+++ b/src/data/workshops.ts
@@ -9,7 +9,7 @@ export type Workshop = {
   targetAudience: string
   highlights?: string[]
   syllabus: Array<{
-    week: number
+    day: number
     title: string
     objective: string
     activities: string[]
@@ -38,164 +38,187 @@ export type Workshop = {
 
 export const workshops: Workshop[] = [
   {
-    slug: 'ai-robotics-beginners',
-    title: 'AI and Robotics for Beginners: Building Smart Machines',
+    slug: 'two-day-ai-robotics',
+    title: 'Two-Day AI & Robotics Workshop',
     overview:
-      'An introductory, hands-on course where high-school students learn core AI concepts (machine learning, computer vision, voice recognition) and apply them to control robots and complete real tasks. The course makes AI accessible and exciting through real builds and simple algorithms.',
-    duration: '12 weeks (1 session/week, 2 hours per session)',
+      'A two-day Robotics workshop combining AI creativity and hands-on robot programming, guiding students from basic concepts to competitive challenges while fostering teamwork and problem-solving skills.',
+    duration: '2 days (9:30–12:00, 13:30–16:00 each day)',
     targetAudience:
-      'High school students (ages 14–18), no prior AI/robotics required; interest in tech and problem-solving is recommended.',
+      'Middle to high school students; no prior AI/robotics required. Ideal for ages 12–18.',
     highlights: [
-      'Hands-on robotics builds with beginner-friendly kits',
-      'Intro to AI concepts: ML, computer vision, NLP/voice',
-      'Sensors & autonomy: obstacle avoidance, navigation',
-      'Team collaboration & final demo/competition',
+      'Hands-on robotics experience combining AI and physical programming',
+      'Progressive skill development: single-sensor → dual-sensor → state machines',
+      'Team-based projects fostering collaboration and problem-solving',
+      'Competitive challenges to apply coding logic and optimization under pressure',
+      'Creative integration of AI projects (PartyRock) with robotics tasks',
     ],
     syllabus: [
-      { week: 1, title: 'Introduction to AI & Robotics', objective: 'Understand course scope, safety, and what AI/robots are', activities: ['Course overview and safety', 'AI & robotics in the real world', 'Team setup and kit introduction'] },
-      { week: 2, title: 'Coding for Robotics', objective: 'Build logic/control using visual programming', activities: ['Blocks/Scratch basics', 'Loops and conditions on robot', 'Test simple movement'] },
-      { week: 3, title: 'Sensors & Environment Understanding', objective: 'Read sensors and interpret surroundings', activities: ['Ultrasonic distance demo', 'Camera feed basics', 'Obstacle detection exercise'] },
-      { week: 4, title: 'Intro to Machine Learning', objective: 'Grasp training vs. inference via a small project', activities: ['Collect a tiny dataset', 'Train simple pattern classifier', 'Test predictions on robot/sim'] },
-      { week: 5, title: 'Computer Vision in Action', objective: 'Use CV to trigger behaviors', activities: ['Color/object detection', 'Follow-the-line or color trigger', 'Evaluate accuracy and latency'] },
-      { week: 6, title: 'Voice Recognition & NLP', objective: 'Control robot with voice commands', activities: ['Intro to speech/NLP APIs', 'Map commands to actions', 'Safety and fallback rules'] },
-      { week: 7, title: 'Autonomous Robots', objective: 'Combine sensors for autonomous navigation', activities: ['Finite-state behavior', 'Obstacle avoidance challenge', 'Tuning and iteration'] },
-      { week: 8, title: 'AI Planning', objective: 'Plan paths and reason about goals', activities: ['Grid/maze path planning', 'Heuristics and constraints', 'Dry-run then on robot'] },
-      { week: 9, title: 'Collaborative Robots', objective: 'Coordinate multi-robot teamwork', activities: ['Define comms/hand-off rules', 'Cooperative relay challenge', 'Post-mortem learnings'] },
-      { week: 10, title: 'Ethical AI & Robotics', objective: 'Consider ethics, safety, and impact', activities: ['Case studies and debate', 'Project risk assessment', 'Responsible use checklist'] },
-      { week: 11, title: 'Final Project Build', objective: 'Design and implement team solution', activities: ['Project sprint', 'Testing and refinement', 'Prepare presentation'] },
-      { week: 12, title: 'Presentation & Competition', objective: 'Communicate results and reflect', activities: ['Demo/competition day', 'Peer feedback', 'Reflection and next steps'] },
-    ],
-    materials: {
-      hardware: ['Beginner robot kits (e.g., Lego Mindstorms, VEX, Arduino-based with sensors/motors)'],
-      software: ['Blockly', 'Scratch', 'Python (beginner-friendly)'],
-      onlineResources: ['Beginner tutorials', 'Coding exercises', 'AI learning references'],
-    },
-    assessment: [
-      { item: 'Hands-on Projects', weight: '60%', criteria: 'Design, functionality, creativity' },
-      { item: 'Teamwork & Collaboration', weight: '20%', criteria: 'Contribution, cooperation' },
-      { item: 'Final Presentation', weight: '20%', criteria: 'Solution quality; clarity of AI/sensor explanation' },
-    ],
-    learningOutcomes: [
-      'Understand basics of AI (ML, CV, NLP)',
-      'Use sensors & simple AI algorithms to control robots',
-      'Explain how autonomy emerges from sensing + decision-making',
-      'Strengthen problem-solving, critical thinking, collaboration',
-      'Gain practical coding & robot design experience',
-    ],
-    media: {
-      video: {
-        src: 'https://www.w3schools.com/html/mov_bbb.mp4',
-        poster: 'https://picsum.photos/seed/airbotix-ai-robotics/800/450',
-        caption: 'Classroom highlights: hands-on AI & robotics.',
+      {
+        day: 1,
+        title: 'AI + Robotics Foundations',
+        objective:
+          'Introduce students to AI and basic robotics concepts while fostering teamwork and hands-on problem-solving skills.',
+        activities: [
+          'Introductory talk on AI and group formation',
+          'Generative AI demo and PartyRock logo project',
+          'Task 1: Generate team logos with PartyRock',
+          'Introductory talk on robotics and mBot overview',
+          'Task 2: Rocket Launch — program robot to move and stop precisely',
+          'Task 3: Line tracking with one sensor, coding and mini challenges',
+          'Conclusion: recap, team sharing, and awards'
+        ],
       },
+      {
+        day: 2,
+        title: 'Robotics + Competition',
+        objective:
+          'Advance students’ robotics skills with dual-sensor programming, state machines, and competitive challenges to reinforce coding logic, precision, and teamwork.',
+        activities: [
+          'Introductory talk on Scratch coding logic: loops and conditional statements',
+          'Demo: Line tracking with 2 sensors',
+          'Task 4: Line tracking with 2 sensors on narrow line',
+          'Talk on logic tables and simple state machines',
+          'Task 5: Line tracking with 2 sensors on wide line',
+          'Task 6: Competition on Space Map',
+          'Conclusion: recap, team sharing, and awards'
+        ],
+      },
+    ],
+    materials: {
+        hardware: [
+            'mBot robots',
+            'IR sensors',
+            'Ultrasonic sensors',
+            'Obstacle course / maps',
+            'Computers for programming'
+        ],
+        software: [
+            'Scratch (for robot programming)',
+            'PartyRock apps (for generative AI projects)'
+        ],
+        onlineResources: [
+            'PartyRock tutorials and demos',
+            'Competition maps / coding examples'
+        ]
+    },
+    assessment: [
+      { item: 'Hands-on Tasks', weight: '60%', criteria: 'Functionality, iteration, teamwork' },
+      { item: 'Competition Performance', weight: '20%', criteria: 'Accuracy, speed, optimization' },
+      { item: 'Presentation/Reflection', weight: '20%', criteria: 'Clarity of logic and learning' },
+    ],
+    learningOutcomes: [
+      'Understand basic AI concepts and their applications in daily life',
+      'Develop foundational robotics skills, including motion control and sensor usage',
+      'Practice coding logic and problem-solving through hands-on tasks',
+      'Apply dual-sensor tracking and simple state machines for improved robot navigation',
+      'Enhance teamwork, collaboration, and iterative design skills',
+      'Experience competitive scenarios to reinforce coding precision, optimization, and creative thinking'
+    ],
+    media: {
       photos: [
-        { src: 'https://images.unsplash.com/photo-1555255707-c07966088b7b?q=80&w=1200&auto=format&fit=crop', alt: 'Students building a robot' },
-        { src: 'https://images.unsplash.com/photo-1551836022-d5d88e9218df?q=80&w=1200&auto=format&fit=crop', alt: 'Obstacle avoidance activity' },
-        { src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?q=80&w=1200&auto=format&fit=crop', alt: 'Team collaboration' },
+        { src: 'https://images.unsplash.com/photo-1551836022-d5d88e9218df?q=80&w=1200&auto=format&fit=crop', alt: 'Team robotics activity' },
+        { src: 'https://images.unsplash.com/photo-1526378722484-bd91ca387e72?q=80&w=1200&auto=format&fit=crop', alt: 'AI generative demo' },
       ],
     },
     seo: {
-      title: 'AI & Robotics for Beginners Workshop | Airbotix',
+      title: 'Two-Day AI & Robotics Workshop | Airbotix',
       description:
-        'A 12-week hands-on workshop introducing high-school students to AI and robotics—covering ML, computer vision, voice control, sensors, and autonomy.',
+        'Intensive two-day AI + robotics program: generative AI, mBot basics, 1→2 sensor line tracking, logic tables, state machines, and team competition.',
     },
-    source: 'AI and Robotics for Beginners: Building Smart Machines',
+    source: 'Two-Day AI & Robotics Workshop (Program Outline)',
   },
   {
-    slug: 'robotics-fundamentals',
-    title: 'Robotics Fundamentals: Sensors to Autonomy',
+    slug: 'study-tour-3-day-mia',
+    title: '3 Day Workshop Package – Study Tour (MIA)',
     overview:
-      'Build a solid foundation in robotics by mastering sensors, actuators, and control. Students learn to read the environment and design reliable autonomous behaviors that solve classroom challenges.',
-    duration: '8 weeks (1 session/week, 2 hours)',
-    targetAudience: 'Middle to high school students (Grades 7–10); basic coding helpful but not required',
+      'A 3-day study tour program bridging university-led AI exploration, hands-on robotics challenges, and AI assistant creation. Participants connect academic insights with industry practice and build real prototypes in teams.',
+    duration: '3 days (morning + afternoon sessions each day)',
+    targetAudience:
+      'Study tour participants (ages 14–18) interested in AI, data, and robotics. No prior experience required.',
     highlights: [
-      'Sensor toolkit: distance, line, IMU basics',
-      'Movement control and calibration',
-      'Navigation challenges and iteration',
+      'University and industry-led AI exploration with real case studies',
+      'Robotics challenge day: teamwork and problem-solving under constraints',
+      'AI assistant creation: hardware + LLM integration and voice interaction',
+      'Team presentations and project showcase with recognitions',
     ],
     syllabus: [
-      { week: 1, title: 'Robotics Starter', objective: 'Understand platform and safety', activities: ['Kit overview', 'First drive program'] },
-      { week: 2, title: 'Movement Mastery', objective: 'Accurate motion control', activities: ['Turns and straight-line', 'Speed calibration'] },
-      { week: 3, title: 'Distance Sensing', objective: 'Avoid obstacles', activities: ['Ultrasonic/IR read', 'Stop/slow behavior'] },
-      { week: 4, title: 'Line Following', objective: 'Track lines reliably', activities: ['PID-lite explanation', 'Tune thresholds'] },
-      { week: 5, title: 'State Machines', objective: 'Structure robot logic', activities: ['Finite states for tasks', 'Fallback and recovery'] },
-      { week: 6, title: 'Localization Lite', objective: 'Estimate position', activities: ['Dead-reckoning idea', 'Waypoint demo'] },
-      { week: 7, title: 'Course Challenge', objective: 'Plan route under constraints', activities: ['Scout course', 'Plan and iterate'] },
-      { week: 8, title: 'Showcase', objective: 'Demonstrate robustness', activities: ['Timed run', 'Peer review'] },
+      {
+        day: 1,
+        title: 'The Age of Intelligence: AI Exploration Camp',
+        objective:
+          'Understand cutting-edge AI tools (LLMs, generative AI, automation, analytics) and their real-world impact; form teams and initiate an AI product challenge with academic/industry mentorship.',
+        activities: [
+          'Lectures by university researchers and industry engineers on LLMs, generative AI, automation, analytics',
+          'Case studies across education, healthcare, finance, and creative industries',
+          'Team formation (4–5 students) and AI project brief selection',
+          'Mentored ideation: intelligent TA, BI tools, or social-good AI concepts',
+          'Project planning and initial prototype design',
+        ],
+      },
+      {
+        day: 2,
+        title: 'Shaping the Future: Robotics Challenge Camp',
+        objective:
+          'Gain foundational robotics knowledge (mechanics, algorithms, control) and apply it in a competitive team challenge to experience hands-on problem-solving and collaboration.',
+        activities: [
+          'Lecture: robotics overview – mechanical design, intelligent algorithms, automation control',
+          'Hands-on practice: robot setup, sensing, and basic control tasks',
+          'Team robotics challenge with real-time contests and scoring',
+          'Reflection on teamwork, iteration, and learning-by-doing',
+        ],
+      },
+      {
+        day: 3,
+        title: 'Smart Companions: AI Creation Camp',
+        objective:
+          'Learn AI hardware and assistant architectures; build and customize an AI assistant with sensors and voice/command control; present projects and receive certifications and recognition.',
+        activities: [
+          'Morning lecture: AI chips/sensors; LLM integration for voice and perception; assistant design principles',
+          'Case studies: architectures and future trends of AI assistants',
+          'Afternoon build: assemble sensors/voice modules/compute; integrate AI models',
+          'Customization: voice style, responses, and interactive scenarios',
+          'Team presentations and closing showcase with certificates and awards',
+        ],
+      },
     ],
     materials: {
-      hardware: ['Robotics kit with motors and sensor pack'],
-      software: ['Block coding or beginner Python'],
-      onlineResources: ['Navigation tips', 'PID basics (intro)'],
+      hardware: [
+        'Robotics kits with sensors and actuators',
+        'AI assistant components: microphones, speakers, sensor modules',
+        'Edge compute units (e.g., microcontrollers or SBCs)',
+      ],
+      software: [
+        'Block/Scratch or Python environment for robotics',
+        'LLM/voice integration tools for AI assistants',
+      ],
+      onlineResources: [
+        'Case studies and slides (AI topics and assistant architecture)',
+        'Robotics challenge maps and starter examples',
+      ],
     },
     assessment: [
-      { item: 'Weekly labs', weight: '50%', criteria: 'Functionality and iteration' },
-      { item: 'Final course run', weight: '30%', criteria: 'Accuracy and reliability' },
-      { item: 'Reflection', weight: '20%', criteria: 'Design decisions and learning' },
+      { item: 'Team Projects', weight: '50%', criteria: 'Functionality, design clarity, impact' },
+      { item: 'Robotics Challenge', weight: '30%', criteria: 'Performance, iteration, teamwork' },
+      { item: 'Presentation/Showcase', weight: '20%', criteria: 'Communication, reflection, polish' },
     ],
     learningOutcomes: [
-      'Control motion with calibrated parameters',
-      'Use sensors to perceive environment',
-      'Design robust behaviors using state machines',
+      'Explain modern AI domains and real-world applications using case studies',
+      'Apply robotics concepts through team challenges and iterative problem-solving',
+      'Design and build an AI assistant integrating sensors and LLM-driven interaction',
+      'Collaborate in teams and present technical work effectively',
     ],
     media: {
       photos: [
-        { src: 'https://images.unsplash.com/photo-1550439062-609e1531270e?q=80&w=1200&auto=format&fit=crop', alt: 'Line following practice' },
-        { src: 'https://images.unsplash.com/photo-1555255707-c07966088b7b?q=80&w=1200&auto=format&fit=crop', alt: 'Obstacle avoidance' },
+        { src: 'https://images.unsplash.com/photo-1551836022-d5d88e9218df?q=80&w=1200&auto=format&fit=crop', alt: 'Team robotics challenge' },
+        { src: 'https://images.unsplash.com/photo-1526378722484-bd91ca387e72?q=80&w=1200&auto=format&fit=crop', alt: 'AI lecture and exploration' },
       ],
     },
     seo: {
-      title: 'Robotics Fundamentals Workshop | Airbotix',
-      description: 'Sensors, movement control, and autonomy foundations for Grades 7–10.',
+      title: '3 Day Study Tour Workshop (MIA) | Airbotix',
+      description:
+        'University + industry AI exploration, robotics challenge, and AI assistant creation across 3 days. Team projects with showcase and certifications.',
     },
-    source: 'Airbotix curriculum',
-  },
-  {
-    slug: 'computer-vision-makers',
-    title: 'Computer Vision for Young Makers',
-    overview:
-      'Learn how computers see. Students collect images, label datasets, and build simple vision pipelines to detect colors, shapes, or objects, powering interactive projects and installations.',
-    duration: '6 weeks (1 session/week, 2 hours)',
-    targetAudience: 'Ages 12–16; creative coding and maker enthusiasts',
-    highlights: [
-      'Data collection and labeling',
-      'Train lightweight classifiers',
-      'Interactive projects (art/installation)',
-    ],
-    syllabus: [
-      { week: 1, title: 'Vision Basics', objective: 'Understand images and pixels', activities: ['Color spaces', 'Capture with webcam'] },
-      { week: 2, title: 'Data Matters', objective: 'Collect useful datasets', activities: ['Labeling practice', 'Bias and quality'] },
-      { week: 3, title: 'Build a Classifier', objective: 'Train and test', activities: ['Split data', 'Evaluate predictions'] },
-      { week: 4, title: 'Real-time Detection', objective: 'Make it live', activities: ['Camera inference', 'Trigger events'] },
-      { week: 5, title: 'Project Sprint', objective: 'Prototype idea', activities: ['Design interaction', 'Integrate detection'] },
-      { week: 6, title: 'Show & Tell', objective: 'Share results', activities: ['Demo day', 'Peer critique'] },
-    ],
-    materials: {
-      hardware: ['Laptop with webcam'],
-      software: ['Block/Python toolkit', 'Lightweight vision library'],
-      onlineResources: ['Dataset tips', 'Ethical imagery guidelines'],
-    },
-    assessment: [
-      { item: 'Mini projects', weight: '60%', criteria: 'Originality and functionality' },
-      { item: 'Participation', weight: '20%', criteria: 'Studio practice and feedback' },
-      { item: 'Final demo', weight: '20%', criteria: 'Clarity and polish' },
-    ],
-    learningOutcomes: [
-      'Collect and label image data responsibly',
-      'Train and evaluate simple classifiers',
-      'Create interactive experiences powered by vision',
-    ],
-    media: {
-      photos: [
-        { src: 'https://images.unsplash.com/photo-1526378722484-bd91ca387e72?q=80&w=1200&auto=format&fit=crop', alt: 'Labeling dataset' },
-        { src: 'https://images.unsplash.com/photo-1542831371-29b0f74f9713?q=80&w=1200&auto=format&fit=crop', alt: 'Real-time detection' },
-      ],
-    },
-    seo: {
-      title: 'Computer Vision for Young Makers | Airbotix',
-      description: 'Collect, label, train, and build interactive vision projects in 6 weeks.',
-    },
-    source: 'Airbotix curriculum',
+    source: '3 Day Workshop Package – For Study Tour (MIA)',
   },
 ]
 

--- a/src/pages/WorkshopDetail.tsx
+++ b/src/pages/WorkshopDetail.tsx
@@ -53,8 +53,8 @@ const WorkshopDetail = () => {
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">Workshop Outline</h2>
             <div className="space-y-5">
               {item.syllabus.map((s) => (
-                <div key={s.week} className="p-5 border border-gray-200 rounded-xl">
-                  <div className="font-semibold text-gray-900 mb-1">Week {s.week}: {s.title}</div>
+                <div key={s.day} className="p-5 border border-gray-200 rounded-xl">
+                  <div className="font-semibold text-gray-900 mb-1">Day {s.day}: {s.title}</div>
                   <div className="text-sm text-gray-600 mb-2">Objective: {s.objective}</div>
                   <ul className="list-disc pl-5 text-gray-700 space-y-1">
                     {s.activities.map((t) => (


### PR DESCRIPTION
### Summary
- Switch workshop syllabus from week-based to day-based.
- No UI redesign; `WorkshopDetail` updated to display “Day X”.
- Add Two-Day AI & Robotics and 3-Day Study Tour (MIA) workshop.
- Remove legacy workshop entries.

### Changes
- Updated:
  - `src/pages/WorkshopDetail.tsx`: render “Day {s.day}” and key by `day`.
- Added:
  - `src/data/workshops.ts`: `two-day-ai-robotics`, `study-tour-3-day-mia`.
- Removed:
  - Deprecated workshops with placeholder data:
    - `ai-robotics-beginners`
    - `robotics-fundamentals`
    - `computer-vision-makers`

### Notes
- Content is hardcoded