### PR TITLE
Feat/workshop UI improve: add duration filters (1d/2d/3d/other)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
+      "integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1432,9 +1432,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2151,9 +2151,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.212",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.212.tgz",
-      "integrity": "sha512-gE7ErIzSW+d8jALWMcOIgf+IB6lpfsg6NwOhPVwKzDtN2qcBix47vlin4yzSregYDxTCXOUqAZjVY/Z3naS7ww==",
+      "version": "1.5.214",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
+      "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
       "dev": true,
       "license": "ISC"
     },

--- a/src/pages/Workshops.tsx
+++ b/src/pages/Workshops.tsx
@@ -126,20 +126,9 @@ const Workshops = () => {
                       {ws.title}
                     </Link>
                   </h3>
-                  <div className="flex flex-col items-end gap-1 max-w-[35%]">
-                    <span className="text-xs sm:text-sm text-primary-700 bg-primary-50 px-2 py-1 rounded-full font-medium line-clamp-2 text-center">
-                      {ws.targetAudience || 'All levels'}
-                    </span>
-                    <span className="text-[10px] sm:text-xs text-gray-600 bg-gray-100 px-2 py-0.5 rounded-full font-medium text-center">
-                      {(() => {
-                        const tag = deriveDurationFilter(ws.duration)
-                        if (tag === WORKSHOP_FILTERS.ONE_DAY) return WORKSHOP_TEXTS.FILTER_1D
-                        if (tag === WORKSHOP_FILTERS.TWO_DAY) return WORKSHOP_TEXTS.FILTER_2D
-                        if (tag === WORKSHOP_FILTERS.THREE_DAY) return WORKSHOP_TEXTS.FILTER_3D
-                        return WORKSHOP_TEXTS.FILTER_OTHER
-                      })()}
-                    </span>
-                  </div>
+                  <span className="text-xs sm:text-sm text-primary-700 bg-primary-50 px-2 py-1 rounded-full font-medium max-w-[35%] line-clamp-2 text-center">
+                    {ws.targetAudience || 'All levels'}
+                  </span>
                 </div>
                 <p className="text-gray-600 mb-4 line-clamp-4">{ws.overview}</p>
                 {ws.highlights && (

--- a/src/pages/Workshops.tsx
+++ b/src/pages/Workshops.tsx
@@ -1,24 +1,120 @@
+import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { workshops as data } from '../data/workshops'
 
+// File-level constants to avoid magic strings
+const WORKSHOP_FILTERS = {
+  ALL: 'all',
+  ONE_DAY: '1d',
+  TWO_DAY: '2d',
+  THREE_DAY: '3d',
+  OTHER: 'other',
+} as const
+
+const WORKSHOP_TEXTS = {
+  PAGE_TITLE: 'Workshops',
+  PAGE_DESC: 'See our past workshops, designed with flexibility to meet your needs.',
+  FILTER_ALL: 'All',
+  FILTER_1D: '1 day',
+  FILTER_2D: '2 day',
+  FILTER_3D: '3 day',
+  FILTER_OTHER: 'Other',
+  VIEW_DETAILS: 'View Details',
+  BOOK: 'Book',
+  EMPTY_TITLE: 'No workshops match your filter',
+  EMPTY_DESC: 'Try adjusting the duration filter or check back soon for new programs.',
+  CLEAR_FILTERS: 'Clear filters',
+  CTA_TITLE: 'Bring Airbotix to your school',
+  CTA_DESC: 'Tailored programs for different age groups, class sizes, and learning objectives.',
+  CTA_CONTACT: 'Contact Us',
+} as const
+
+type DurationFilter = typeof WORKSHOP_FILTERS[keyof typeof WORKSHOP_FILTERS]
+
+const deriveDurationFilter = (duration: string): Exclude<DurationFilter, 'all'> => {
+  const match = duration.toLowerCase().match(/\b(\d+)\s*day/)
+  if (match) {
+    const num = parseInt(match[1], 10)
+    if (num === 1) return WORKSHOP_FILTERS.ONE_DAY
+    if (num === 2) return WORKSHOP_FILTERS.TWO_DAY
+    if (num === 3) return WORKSHOP_FILTERS.THREE_DAY
+  }
+  return WORKSHOP_FILTERS.OTHER
+}
+
 const Workshops = () => {
+  const [selectedDuration, setSelectedDuration] = useState<DurationFilter>(WORKSHOP_FILTERS.ALL)
+
+  const filtered = useMemo(() => {
+    if (selectedDuration === WORKSHOP_FILTERS.ALL) return data
+    return data.filter((ws) => deriveDurationFilter(ws.duration) === selectedDuration)
+  }, [selectedDuration])
+
   return (
     <div>
       {/* Hero */}
       <section className="bg-gradient-to-br from-primary-50 to-secondary-50 py-16 md:py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">Workshops</h1>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">{WORKSHOP_TEXTS.PAGE_TITLE}</h1>
           <p className="text-lg md:text-xl text-gray-600 max-w-3xl mx-auto">
-            Engaging, curriculum-aligned AI & Robotics workshops designed for K-12 students across Australia.
+            {WORKSHOP_TEXTS.PAGE_DESC}
           </p>
+        </div>
+      </section>
+
+      {/* Filters */}
+      <section className="py-8 bg-white border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-wrap gap-2">
+            {[
+              { key: WORKSHOP_FILTERS.ALL, label: WORKSHOP_TEXTS.FILTER_ALL },
+              { key: WORKSHOP_FILTERS.ONE_DAY, label: WORKSHOP_TEXTS.FILTER_1D },
+              { key: WORKSHOP_FILTERS.TWO_DAY, label: WORKSHOP_TEXTS.FILTER_2D },
+              { key: WORKSHOP_FILTERS.THREE_DAY, label: WORKSHOP_TEXTS.FILTER_3D },
+              { key: WORKSHOP_FILTERS.OTHER, label: WORKSHOP_TEXTS.FILTER_OTHER },
+            ].map((f) => (
+              <button
+                key={f.key}
+                onClick={() => setSelectedDuration(f.key as DurationFilter)}
+                className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                  selectedDuration === f.key
+                    ? 'bg-primary-600 text-white'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
         </div>
       </section>
 
       {/* Cards */}
       <section className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          {filtered.length === 0 ? (
+            <div className="text-center py-12">
+              <div className="max-w-md mx-auto">
+                <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                </div>
+                <h3 className="text-xl font-semibold text-gray-900 mb-2">{WORKSHOP_TEXTS.EMPTY_TITLE}</h3>
+                <p className="text-gray-600 mb-6">{WORKSHOP_TEXTS.EMPTY_DESC}</p>
+                {selectedDuration !== WORKSHOP_FILTERS.ALL && (
+                  <button
+                    onClick={() => setSelectedDuration(WORKSHOP_FILTERS.ALL)}
+                    className="btn-primary"
+                  >
+                    {WORKSHOP_TEXTS.CLEAR_FILTERS}
+                  </button>
+                )}
+              </div>
+            </div>
+          ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {data.map((ws) => (
+            {filtered.map((ws) => (
               <div key={ws.slug} className="border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition-shadow p-6 flex flex-col">
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="text-xl font-semibold text-gray-900 max-w-[65%] line-clamp-3">
@@ -30,9 +126,20 @@ const Workshops = () => {
                       {ws.title}
                     </Link>
                   </h3>
-                  <span className="text-xs sm:text-sm text-primary-700 bg-primary-50 px-2 py-1 rounded-full font-medium max-w-[35%] line-clamp-2 text-center">
-                    {ws.targetAudience || 'All levels'}
-                  </span>
+                  <div className="flex flex-col items-end gap-1 max-w-[35%]">
+                    <span className="text-xs sm:text-sm text-primary-700 bg-primary-50 px-2 py-1 rounded-full font-medium line-clamp-2 text-center">
+                      {ws.targetAudience || 'All levels'}
+                    </span>
+                    <span className="text-[10px] sm:text-xs text-gray-600 bg-gray-100 px-2 py-0.5 rounded-full font-medium text-center">
+                      {(() => {
+                        const tag = deriveDurationFilter(ws.duration)
+                        if (tag === WORKSHOP_FILTERS.ONE_DAY) return WORKSHOP_TEXTS.FILTER_1D
+                        if (tag === WORKSHOP_FILTERS.TWO_DAY) return WORKSHOP_TEXTS.FILTER_2D
+                        if (tag === WORKSHOP_FILTERS.THREE_DAY) return WORKSHOP_TEXTS.FILTER_3D
+                        return WORKSHOP_TEXTS.FILTER_OTHER
+                      })()}
+                    </span>
+                  </div>
                 </div>
                 <p className="text-gray-600 mb-4 line-clamp-4">{ws.overview}</p>
                 {ws.highlights && (
@@ -57,28 +164,29 @@ const Workshops = () => {
                   </div>
                   <div className="flex gap-2 w-full sm:w-auto">
                     <Link to={`/workshops/${ws.slug}`} className="btn-outline w-full sm:w-auto text-center">
-                      View Details
+                      {WORKSHOP_TEXTS.VIEW_DETAILS}
                     </Link>
                     <Link to={`/book?workshop=${ws.slug}`} className="btn-primary w-full sm:w-auto">
-                      Book
+                      {WORKSHOP_TEXTS.BOOK}
                     </Link>
                   </div>
                 </div>
               </div>
             ))}
           </div>
+          )}
         </div>
       </section>
 
       {/* CTA */}
       <section className="py-16 bg-primary-600">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Bring Airbotix to your school</h2>
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">{WORKSHOP_TEXTS.CTA_TITLE}</h2>
           <p className="text-primary-100 max-w-2xl mx-auto mb-8">
-            Tailored programs for different age groups, class sizes, and learning objectives.
+            {WORKSHOP_TEXTS.CTA_DESC}
           </p>
           <button className="bg-white text-primary-600 hover:bg-gray-50 font-semibold text-lg px-8 py-3 rounded-lg transition-colors">
-            Contact Us
+            {WORKSHOP_TEXTS.CTA_CONTACT}
           </button>
         </div>
       </section>


### PR DESCRIPTION
### Description

**Goal**
Improve UX as the number of workshops grows by enabling quick duration-based filtering, reducing noise and speeding up discovery.

**Changes**

* Update `src/pages/Workshops.tsx`

  * Add UI and interaction logic for duration-based filtering

### Screenshots

**Filter Button Group**
Options: `All / 1 day / 2 day / 3 day / Other` <img width="1512" height="982" alt="Screenshot 2025-09-04 at 21 52 30" src="https://github.com/user-attachments/assets/83327860-7ae6-4911-8238-60bab888f256" />

**Empty State + Clear Button** <img width="1512" height="982" alt="Screenshot 2025-09-04 at 21 52 35" src="https://github.com/user-attachments/assets/94c7478b-f213-4044-9be0-d58d391d1653" />