### PR TITLE
feat(home): update workshop gallery images (local media)

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -93,36 +93,36 @@ const Home = () => {
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
             {[
               {
-                src: 'https://images.unsplash.com/photo-1581091014534-7f3c2b3a2f9b?q=80&w=1200&auto=format&fit=crop',
-                alt: 'Student programming a robot',
+                src: '/media/pacific-camp/photos/activities-03.jpg',
+                alt: 'Hands-on robotics activity',
               },
               {
-                src: 'https://images.unsplash.com/photo-1555255707-c07966088b7b?q=80&w=1200&auto=format&fit=crop',
-                alt: 'Robotics workshop table',
+                src: '/media/pacific-camp/photos/activities-04.jpg',
+                alt: 'Team coding challenge',
               },
               {
-                src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?q=80&w=1200&auto=format&fit=crop',
-                alt: 'AI and coding session',
+                src: '/media/pacific-camp/photos/activities-05.jpg',
+                alt: 'Students testing robot',
               },
               {
-                src: 'https://images.unsplash.com/photo-1542831371-29b0f74f9713?q=80&w=1200&auto=format&fit=crop',
-                alt: 'Teamwork on a challenge',
+                src: '/media/pacific-camp/photos/activities-06.jpg',
+                alt: 'AI workshop session',
               },
               {
-                src: 'https://images.unsplash.com/photo-1551836022-d5d88e9218df?q=80&w=1200&auto=format&fit=crop',
-                alt: 'Electronics and prototyping',
+                src: '/media/pacific-camp/photos/activities-07.jpg',
+                alt: 'Group robotics build',
               },
               {
-                src: 'https://images.unsplash.com/photo-1550439062-609e1531270e?q=80&w=1200&auto=format&fit=crop',
-                alt: 'Computer vision demo',
+                src: '/media/pacific-camp/photos/activities-08.jpg',
+                alt: 'Class demo and presentation',
               },
               {
-                src: 'https://images.unsplash.com/photo-1526378722484-bd91ca387e72?q=80&w=1200&auto=format&fit=crop',
-                alt: 'Classroom presentation',
+                src: '/media/pacific-camp/photos/classroom-01.jpg',
+                alt: 'Classroom collaboration',
               },
               {
-                src: 'https://images.unsplash.com/photo-1488590528505-98d2b5aba04b?q=80&w=1200&auto=format&fit=crop',
-                alt: 'Coding activity',
+                src: '/media/pacific-camp/photos/outcomes-01.jpg',
+                alt: 'Learning outcomes showcase',
               },
             ].map((img) => (
               <div key={img.src} className="relative overflow-hidden rounded-xl aspect-[4/3] bg-gray-100">


### PR DESCRIPTION
Replace Home page “Workshop Gallery” images with locally hosted assets under public/media/pacific-camp/photos.
Improves load stability and removes external Unsplash dependencies.
No functional changes beyond image sources and alt text improvements.

desktop
<img width="1920" height="1080" alt="Screenshot 2025-09-19 065330" src="https://github.com/user-attachments/assets/b99d28a8-44ec-4865-93fc-e9b1ec5e26a7" />
phone
![Screenshot_2025-09-19-07-13-08-32_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/user-attachments/assets/d318aec4-d6a8-4b8b-aa29-b946e8e1ce15)

tablet
![Screenshot_20250919_071229_Chrome](https://github.com/user-attachments/assets/5ec1ac02-7f8a-4b26-a565-53ffd711c4e7)

变更范围
Modified: src/pages/Home.tsx
Excluded: public/mockServiceWorker.js (local/MSW-generated; not included in this PR)



验收要点
Open Home page (/) and verify 8 gallery images显示正常，hover 缩放效果正常。
图片路径均为 /media/pacific-camp/photos/*.jpg。
Lighthouse/网络面板无外链图片请求。

风险与缓解
低风险：仅本地静态资源路径变更。
若图片未显示，检查 public/media/pacific-camp/photos 是否存在对应文件。
