### PR TITLE
feature: minimal GA integration

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { Toaster } from 'react-hot-toast';
 import App from './App.tsx';
 import './index.css';
 import './i18n';
+import { initAnalytics } from '@/utils/analytics';
 
 // Enable MSW in development
 async function enableMocking() {
@@ -17,6 +18,7 @@ async function enableMocking() {
 }
 
 enableMocking().then(() => {
+  initAnalytics()
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <HashRouter>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,36 @@
+// Minimal GA: inject gtag with measurement ID only
+
+const GA_ID = import.meta.env.VITE_GA4_MEASUREMENT_ID || 'G-0GZNJGRQRB'
+
+let isInitialized = false
+
+function loadGtag(measurementId: string): void {
+  const existingScript = document.getElementById('ga4-script') as HTMLScriptElement | null
+  if (existingScript) return
+
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`
+  script.id = 'ga4-script'
+  document.head.appendChild(script)
+
+  const inline = document.createElement('script')
+  inline.innerHTML = `window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);}`
+  document.head.appendChild(inline)
+}
+
+export function initAnalytics(): void {
+  if (!GA_ID || typeof window === 'undefined') return
+  if (isInitialized) return
+
+  loadGtag(GA_ID)
+  // @ts-expect-error gtag is injected at runtime
+  window.gtag('js', new Date())
+  // @ts-expect-error gtag is injected at runtime
+  window.gtag('config', GA_ID)
+  isInitialized = true
+}
+
+export function trackEvent(_eventName: string, _params?: Record<string, unknown>): void {
+  // No-op in minimal GA setup
+}


### PR DESCRIPTION
Scope
src/utils/analytics.ts: 注入 gtag 并执行 gtag('config', GA_ID)
src/main.tsx: 应用启动时调用 initAnalytics()

Env
VITE_GA4_MEASUREMENT_ID=G-0GZNJGRQRB（如未配置，代码提供相同兜底）
Verification
Build 通过；部署后 Network 可见 gtag/js 请求；GA DebugView 可见 page_view