### PR TITLE
Fix: fix the typescript build error

### DIFF
--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { AuthStore, AuthState } from '@/types/auth';
-import { authAPI, getStoredUser } from '@/services/api';
+import { authAPI, getStoredUser, refreshToken as refreshTokenAPI } from '@/services/api';
 import toast from 'react-hot-toast';
 
 export const useAuthStore = create<AuthStore>((set, get) => ({
@@ -150,7 +150,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   // Refresh token
   refreshToken: async (): Promise<boolean> => {
     try {
-      const success = await authAPI.refreshToken();
+      const success = await refreshTokenAPI();
       if (success) {
         // Optionally refresh user data
         try {


### PR DESCRIPTION
The TypeScript build error was caused by the auth store trying to call authAPI.refreshToken(), but the refreshToken function was exported separately from the API module, not as part of the authAPI object.