### PR TITLE
Add subscription tiers marketing page

### DIFF
--- a/docs/SUBSCRIPTION_CODING_RULES.md
+++ b/docs/SUBSCRIPTION_CODING_RULES.md
@@ -1,0 +1,20 @@
+# Subscription Feature Coding Rules
+
+1. **Single source for pricing**
+   - Only set pricing and tier metadata in `src/data/subscriptionTiers.ts`.
+   - Do not hardcode prices elsewhere; reference the data object.
+
+2. **Typed tier updates**
+   - Preserve the `SubscriptionTier` union for `name` to prevent mismatched badges or copy.
+   - Add new properties to the interface before using them in the page.
+
+3. **Presentation patterns**
+   - Use the existing card layout in `Subscriptions.tsx` as the base for new tiers or badges.
+   - Keep CTAs pointing to `/contact` until a checkout or billing integration exists.
+
+4. **Content consistency**
+   - Highlight popular tiers via `isPopular` rather than string comparisons.
+   - Update guarantee and support copy in-page arrays to keep messaging centralized.
+
+5. **Documentation upkeep**
+   - When changing pricing logic or adding integrations, update all three subscription docs in `docs/` to reflect data flow and usage.

--- a/docs/SUBSCRIPTION_FUNCTION_DOCS.md
+++ b/docs/SUBSCRIPTION_FUNCTION_DOCS.md
@@ -1,0 +1,38 @@
+# Subscription Feature Function Documentation
+
+## Data types
+### `SubscriptionTier`
+Defined in `src/data/subscriptionTiers.ts`.
+```ts
+interface SubscriptionTier {
+  name: 'Silver' | 'Gold' | 'Platinum'
+  priceMonthly: number
+  priceYearly: number
+  description: string
+  features: string[]
+  bestFor: string
+  isPopular?: boolean
+}
+```
+
+## Usage patterns
+- Import `subscriptionTiers` to render pricing cards:
+```tsx
+import { subscriptionTiers } from '@/data/subscriptionTiers'
+
+{subscriptionTiers.map((tier) => (
+  <PricingCard tier={tier} />
+))}
+```
+- Use `isPopular` to flag a badge without comparing string literals.
+- CTA buttons currently link to `/contact` for payment or invoice follow-up.
+
+## Component behaviors
+- `Subscriptions` page maps tier data into cards with pricing, features, and best-fit guidance.
+- Guarantee bullets and support highlights are static arrays within the page for clarity.
+- Payment messaging lives in the "Payment and rollout guidance" panel for easy edits.
+
+## Error handling & constraints
+- Data is static; no runtime fetch errors expected.
+- Keep tier names aligned with the literal union to avoid runtime typos.
+- Avoid embedding pricing in multiple locations—update only `subscriptionTiers` to keep copy consistent.

--- a/docs/SUBSCRIPTION_SYSTEM_DESIGN.md
+++ b/docs/SUBSCRIPTION_SYSTEM_DESIGN.md
@@ -1,0 +1,27 @@
+# Subscription Feature System Design
+
+## Overview
+The subscription feature introduces a dedicated marketing page that outlines paid tiers (Silver, Gold, Platinum) and clarifies payment expectations for schools and partners. It uses static data to render pricing cards, guarantees, and rollout guidance.
+
+## Component hierarchy
+- `src/pages/Subscriptions.tsx`
+  - Hero with positioning copy
+  - Pricing grid sourced from `subscriptionTiers`
+    - CTA buttons linking to Contact
+  - Benefits + payment guidance panels
+
+## Data flow
+- Static tier data lives in `src/data/subscriptionTiers.ts`.
+- The page maps `subscriptionTiers` into cards without external API calls.
+- CTA links route users to `/contact` for payment initiation or invoicing.
+
+## File location mapping
+- Routing entry: `src/App.tsx` registers `/subscriptions`.
+- Navigation access: `src/components/Header.tsx` adds desktop + mobile links.
+- Data source: `src/data/subscriptionTiers.ts` defines tier metadata.
+- Page UI: `src/pages/Subscriptions.tsx` renders all subscription content.
+
+## AI quick-reference
+- Add or adjust tiers by editing `subscriptionTiers` (typed with `SubscriptionTier`).
+- Keep CTAs consistent (`/contact`) until a dedicated checkout flow exists.
+- Popular badge is controlled via `isPopular` on the tier object.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Media from './pages/Media';
 import BlogList from './pages/Blog/BlogList';
 import BlogDetail from './pages/Blog/BlogDetail';
 import FAQ from './pages/FAQ';
+import Subscriptions from './pages/Subscriptions';
 
 // Auth pages
 import Login from './auth/pages/Login';
@@ -71,6 +72,7 @@ function App() {
               <Route path="/book" element={<Book />} />
               <Route path="/media" element={<Media />} />
               <Route path="/faq" element={<FAQ />} />
+              <Route path="/subscriptions" element={<Subscriptions />} />
               <Route path="/blog" element={<BlogList />} />
               <Route path="/blog/:slug" element={<BlogDetail />} />
             </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,6 +49,9 @@ const Header = () => {
             <Link to="/workshops" className="text-gray-700 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium transition-colors">
               {t('nav.workshops', 'Workshops')}
             </Link>
+            <Link to="/subscriptions" className="text-gray-700 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium transition-colors">
+              {t('nav.subscriptions', 'Subscriptions')}
+            </Link>
             <Link to="/blog" className="text-gray-700 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium transition-colors">
               {t('nav.blog', 'Blog')}
             </Link>
@@ -133,6 +136,13 @@ const Header = () => {
                 onClick={() => setIsMenuOpen(false)}
               >
                 {t('nav.workshops', 'Workshops')}
+              </Link>
+              <Link
+                to="/subscriptions"
+                className="block text-gray-700 hover:text-primary-600 px-3 py-2 rounded-md text-base font-medium"
+                onClick={() => setIsMenuOpen(false)}
+              >
+                {t('nav.subscriptions', 'Subscriptions')}
               </Link>
               <Link
                 to="/blog"

--- a/src/data/subscriptionTiers.ts
+++ b/src/data/subscriptionTiers.ts
@@ -1,0 +1,55 @@
+export interface SubscriptionTier {
+  name: 'Silver' | 'Gold' | 'Platinum'
+  priceMonthly: number
+  priceYearly: number
+  description: string
+  features: string[]
+  bestFor: string
+  isPopular?: boolean
+}
+
+export const subscriptionTiers: SubscriptionTier[] = [
+  {
+    name: 'Silver',
+    priceMonthly: 29,
+    priceYearly: 299,
+    description: 'Essential tools for individual educators launching AI & Robotics programs.',
+    features: [
+      '2 instructor seats with shared dashboards',
+      '4 hands-on workshop kits per term',
+      'Digital curriculum library access',
+      'Email support with 48-hour response',
+    ],
+    bestFor: 'Teachers piloting robotics clubs or integrating STEM projects.',
+  },
+  {
+    name: 'Gold',
+    priceMonthly: 59,
+    priceYearly: 599,
+    description: 'Expanded capacity and support for schools running recurring workshops.',
+    features: [
+      '5 instructor seats with role-based permissions',
+      '10 workshop kits per term with replenishment',
+      'Live virtual onboarding for staff',
+      'Priority chat + email support (same business day)',
+      'Student progress analytics exports',
+    ],
+    bestFor: 'School STEM leads scaling term-long robotics and AI learning.',
+    isPopular: true,
+  },
+  {
+    name: 'Platinum',
+    priceMonthly: 99,
+    priceYearly: 999,
+    description: 'Enterprise-grade package with premium content and white-glove delivery.',
+    features: [
+      'Unlimited instructor seats with SSO integration',
+      '20+ workshop kits with spare parts pool',
+      'Custom curriculum design with quarterly planning',
+      'Dedicated success manager with office hours',
+      'Onsite launch day facilitation',
+      'Advanced analytics with cohort benchmarking',
+    ],
+    bestFor: 'Multi-campus networks or education partners delivering large-scale programs.',
+  },
+]

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -1,0 +1,131 @@
+import { CheckCircleIcon } from '@heroicons/react/24/solid'
+import { subscriptionTiers } from '@/data/subscriptionTiers'
+
+const guaranteePoints = [
+  'Cancel or change tiers anytime before renewal',
+  'Secure payments processed via trusted partners',
+  'Invoice receipts for schools and organisations',
+  '30-day success check-in with our team',
+]
+
+const supportHighlights = [
+  {
+    title: 'Flexible billing',
+    description: 'Choose monthly or annual billing with savings for upfront yearly commitments.',
+  },
+  {
+    title: 'Learning resources',
+    description: 'Lesson plans, coding challenges, and safety checklists ready for classrooms.',
+  },
+  {
+    title: 'Onboarding',
+    description: 'Guided setup for dashboards, student groups, and hardware kits in under an hour.',
+  },
+]
+
+const Subscriptions = () => {
+  return (
+    <div className="bg-gray-50">
+      <section className="bg-gradient-to-br from-primary-50 to-secondary-50 py-16 sm:py-24">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-sm font-semibold text-primary-700 uppercase tracking-wide">Subscription plans</p>
+          <h1 className="mt-4 text-4xl sm:text-5xl font-bold text-gray-900">
+            Scale your AI & Robotics program with predictable pricing
+          </h1>
+          <p className="mt-6 text-lg text-gray-600 max-w-3xl mx-auto">
+            Pick a tier that matches your rollout stage—from single-class pilots to multi-campus deployments. Swap tiers anytime,
+            and every plan includes curriculum updates and support.
+          </p>
+        </div>
+      </section>
+
+      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 -mt-12 pb-16 sm:pb-24">
+        <div className="grid gap-8 md:grid-cols-3">
+          {subscriptionTiers.map((tier) => (
+            <div
+              key={tier.name}
+              className={`rounded-2xl bg-white shadow-lg border ${
+                tier.isPopular ? 'border-primary-300 shadow-primary-100' : 'border-gray-200'
+              } flex flex-col h-full`}
+            >
+              <div className="p-8 flex-1 flex flex-col">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-2xl font-bold text-gray-900">{tier.name}</h2>
+                  {tier.isPopular && <span className="px-3 py-1 text-xs font-semibold text-primary-700 bg-primary-100 rounded-full">Most popular</span>}
+                </div>
+                <p className="text-gray-600 mb-6">{tier.description}</p>
+                <div className="mb-6">
+                  <p className="text-4xl font-extrabold text-gray-900">${tier.priceMonthly}</p>
+                  <p className="text-sm text-gray-500">per month, billed monthly</p>
+                  <p className="text-sm text-gray-500 mt-1">or ${tier.priceYearly} billed yearly (save 14%)</p>
+                </div>
+                <div className="space-y-3">
+                  {tier.features.map((feature) => (
+                    <div key={feature} className="flex items-start gap-3">
+                      <CheckCircleIcon className="w-5 h-5 text-primary-600 mt-0.5" />
+                      <p className="text-gray-700">{feature}</p>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-6 p-4 rounded-lg bg-gray-50 border border-gray-100">
+                  <p className="text-sm text-gray-600">{tier.bestFor}</p>
+                </div>
+              </div>
+              <div className="p-8 border-t border-gray-100 bg-gray-50">
+                <a href="/contact" className="btn-primary w-full text-center block">
+                  Start {tier.name.toLowerCase()} plan
+                </a>
+                <p className="text-xs text-gray-500 text-center mt-3">No setup fees. Switching is instant.</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-white border-t border-gray-200 py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid gap-12 lg:grid-cols-2 items-center">
+          <div>
+            <p className="text-sm font-semibold text-primary-700 uppercase tracking-wide">What’s included</p>
+            <h2 className="mt-3 text-3xl font-bold text-gray-900">Subscription benefits designed for educators</h2>
+            <p className="mt-4 text-lg text-gray-600">
+              Each subscription unlocks content, tooling, and human support so your team can deliver confident, safe, and engaging
+              workshops. Upgrade as cohorts grow—your resources and analytics scale with you.
+            </p>
+            <div className="mt-8 space-y-4">
+              {supportHighlights.map((item) => (
+                <div key={item.title} className="p-4 rounded-xl border border-gray-200 bg-gray-50">
+                  <h3 className="text-lg font-semibold text-gray-900">{item.title}</h3>
+                  <p className="mt-2 text-gray-700">{item.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="bg-gray-50 rounded-2xl border border-gray-200 p-8 shadow-sm">
+            <h3 className="text-xl font-semibold text-gray-900">Payment and rollout guidance</h3>
+            <p className="mt-2 text-gray-700">
+              We process payments through secure gateways and can issue invoices for schools. Your subscription activates as soon as
+              payment clears, with immediate access to resources and onboarding support.
+            </p>
+            <div className="mt-6 space-y-3">
+              {guaranteePoints.map((point) => (
+                <div key={point} className="flex items-start gap-3">
+                  <CheckCircleIcon className="w-5 h-5 text-primary-600 mt-0.5" />
+                  <p className="text-gray-700">{point}</p>
+                </div>
+              ))}
+            </div>
+            <div className="mt-8 p-4 rounded-xl bg-white border border-primary-100">
+              <p className="text-sm font-medium text-primary-700">Looking for procurement paperwork?</p>
+              <p className="text-sm text-gray-700 mt-2">
+                We provide supplier forms, insurance certificates, and student safety outlines for compliance reviews. Reach out and
+                our team will bundle them with your subscription quote.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default Subscriptions


### PR DESCRIPTION
## Summary
- add dedicated subscription tiers marketing page with pricing cards, guarantees, and support guidance
- register the subscriptions route and navigation links for desktop and mobile menus
- document subscription feature design, usage patterns, and coding rules

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69281d6126808332990b16df7265ad45)